### PR TITLE
Fix: Order 테이블 이름을 Orders로 변경

### DIFF
--- a/src/main/java/fourtalking/Nateam/order/entity/Orders.java
+++ b/src/main/java/fourtalking/Nateam/order/entity/Orders.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order extends BaseCreatedTimeEntity {
+public class Orders extends BaseCreatedTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)


### PR DESCRIPTION
데이터베이스에서 Order는 예약어기 때문에 Order 테이블이 만들어 지지 않는 오류가 발생하여 Orders로 변경