### PR TITLE
Refactor: 모든 리뷰 User 기능 추가 및 리뷰 ResponseDTO 순서 변경

### DIFF
--- a/src/main/java/fourtalking/Nateam/global/exception/common/ErrorCode.java
+++ b/src/main/java/fourtalking/Nateam/global/exception/common/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
   NOT_FOUND_GAME_EXCEPTION(401, "게임 정보를 찾을 수 없습니다."),
 
   // 리뷰
-  NOT_FOUND_REVIEW_EXCEPTION(401, "리뷰 정보를 찾을 수 없습니다.");
+  NOT_FOUND_REVIEW_EXCEPTION(401, "리뷰 정보를 찾을 수 없습니다."),
+  INCONSISTENCY_USERID_EXCEPTION(401, "유저 아이디가 일치하지 않습니다.");
 
   private final int status;
 

--- a/src/main/java/fourtalking/Nateam/global/exception/review/InconsistencyUserIdException.java
+++ b/src/main/java/fourtalking/Nateam/global/exception/review/InconsistencyUserIdException.java
@@ -1,0 +1,11 @@
+package fourtalking.Nateam.global.exception.review;
+
+import fourtalking.Nateam.global.exception.common.BusinessException;
+import fourtalking.Nateam.global.exception.common.ErrorCode;
+
+public class InconsistencyUserIdException extends BusinessException {
+
+    public InconsistencyUserIdException() {
+        super(ErrorCode.INCONSISTENCY_USERID_EXCEPTION);
+    }
+}

--- a/src/main/java/fourtalking/Nateam/review/controller/ReviewController.java
+++ b/src/main/java/fourtalking/Nateam/review/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package fourtalking.Nateam.review.controller;
 
+import fourtalking.Nateam.global.security.userdetails.UserDetailsImpl;
 import fourtalking.Nateam.review.dto.GetAllReviewDTO;
 import fourtalking.Nateam.review.dto.GetReviewDTO;
 import fourtalking.Nateam.review.dto.ReviewRegisterDTO;
@@ -10,6 +11,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,29 +30,26 @@ public class ReviewController {
 
     @PostMapping("/{gameId}")
     public ResponseEntity<ReviewRegisterDTO.Response> registerReview(
-            //@AuthenticationPrincipal UserDetailsImpl userDetails,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable("gameId") Long gameId,
             @RequestBody @Valid ReviewRegisterDTO.Request reviewRequest) {
 
-        Response reviewResponseDTO = reviewService.registerReview(gameId, reviewRequest);
+        Response reviewResponseDTO = reviewService.registerReview(userDetails.getUser().getUserId(),
+                gameId, reviewRequest);
 
         return ResponseEntity.ok(reviewResponseDTO);
     }
 
     @GetMapping("/{reviewId}")
-    public ResponseEntity<GetReviewDTO> getReview(
-            //
-            @PathVariable("reviewId") Long reviewId) {
+    public ResponseEntity<GetReviewDTO> getReview(@PathVariable("reviewId") Long reviewId) {
 
-        GetReviewDTO getReviewDTO = reviewService.getReview("khj",reviewId);
+        GetReviewDTO getReviewDTO = reviewService.getReview(reviewId);
 
         return ResponseEntity.ok(getReviewDTO);
     }
 
     @GetMapping("/{gameId}/reviews")
-    public ResponseEntity<List<GetAllReviewDTO>> getAllReview(@PathVariable("gameId") Long gameId
-            //, @AuthenticationPrincipal UserDetailsImpl userDetails,
-            ) {
+    public ResponseEntity<List<GetAllReviewDTO>> getAllReview(@PathVariable("gameId") Long gameId) {
 
         List<GetAllReviewDTO> getAllReviewDTO = reviewService.getAllReview(gameId);
 
@@ -58,22 +57,22 @@ public class ReviewController {
     }
 
     @PatchMapping("/{reviewId}")
-    public ResponseEntity<UpdateReviewDTO.Response> updateReview(@PathVariable("reviewId") Long reviewId,
-            @RequestBody @Valid UpdateReviewDTO.Request request
-            //, @AuthenticationPrincipal UserDetailsImpl userDetails,
-    ) {
+    public ResponseEntity<UpdateReviewDTO.Response> updateReview(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("reviewId") Long reviewId,
+            @RequestBody @Valid UpdateReviewDTO.Request request) {
 
-        UpdateReviewDTO.Response response = reviewService.updateReview(reviewId, request);
+        UpdateReviewDTO.Response response = reviewService.updateReview(userDetails.getUser()
+                .getUserId(), reviewId, request);
 
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{reviewId}")
-    public ResponseEntity<String> deleteReview(@PathVariable("reviewId") Long reviewId
-            //, @AuthenticationPrincipal UserDetailsImpl userDetails,
-    ) {
+    public ResponseEntity<String> deleteReview(@AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("reviewId") Long reviewId) {
 
-        reviewService.deleteReview(reviewId);
+        reviewService.deleteReview(userDetails.getUser().getUserId(), reviewId);
 
         return ResponseEntity.ok("삭제 성공");
     }

--- a/src/main/java/fourtalking/Nateam/review/dto/GetReviewDTO.java
+++ b/src/main/java/fourtalking/Nateam/review/dto/GetReviewDTO.java
@@ -1,6 +1,7 @@
 package fourtalking.Nateam.review.dto;
 
 import fourtalking.Nateam.review.entity.Review;
+import fourtalking.Nateam.user.entity.User;
 import java.time.LocalDateTime;
 import lombok.Builder;
 
@@ -15,11 +16,11 @@ public record GetReviewDTO(
         LocalDateTime lastModifiedDate
 ) {
 
-    public static GetReviewDTO of(String userName, Review review){
+    public static GetReviewDTO of(User user, Review review){
 
         return GetReviewDTO.builder()
-                .userName(userName)
                 .gameId(review.getGameId())
+                .userName(user.getUserName())
                 .reviewId(review.getReviewId())
                 .reviewContent(review.getReviewContent())
                 .reviewRank(review.getReviewRank())

--- a/src/main/java/fourtalking/Nateam/review/dto/ReviewRegisterDTO.java
+++ b/src/main/java/fourtalking/Nateam/review/dto/ReviewRegisterDTO.java
@@ -1,6 +1,7 @@
 package fourtalking.Nateam.review.dto;
 
 import fourtalking.Nateam.review.entity.Review;
+import fourtalking.Nateam.user.entity.User;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -13,9 +14,9 @@ public class ReviewRegisterDTO{
     public record Request(
             @NotBlank @Size(max = 255) String reviewContent,
             @Min(1) @Max(5) int reviewRank) {
-        public Review toEntity(Long gameId) {
+        public Review toEntity(Long userId, Long gameId) {
             return Review.builder()
-                    .userId(1L)
+                    .userId(userId)
                     .gameId(gameId)
                     .reviewContent(reviewContent)
                     .reviewRank(reviewRank)
@@ -24,12 +25,13 @@ public class ReviewRegisterDTO{
     }
 
     @Builder
-    public record Response(Long userId, Long gameId, String reviewContent, int reviewRank, LocalDateTime createdDate) {
+    public record Response(Long gameId, String userName, Long reviewId, String reviewContent, int reviewRank, LocalDateTime createdDate) {
 
-        public static Response of(Review review) {
+        public static Response of(User user, Review review) {
             return Response.builder()
-                    .userId(review.getUserId())
                     .gameId(review.getGameId())
+                    .userName(user.getUserName())
+                    .reviewId(review.getReviewId())
                     .reviewContent(review.getReviewContent())
                     .reviewRank(review.getReviewRank())
                     .createdDate(review.getCreatedTime())

--- a/src/main/java/fourtalking/Nateam/review/dto/UpdateReviewDTO.java
+++ b/src/main/java/fourtalking/Nateam/review/dto/UpdateReviewDTO.java
@@ -1,6 +1,7 @@
 package fourtalking.Nateam.review.dto;
 
 import fourtalking.Nateam.review.entity.Review;
+import fourtalking.Nateam.user.entity.User;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -17,14 +18,14 @@ public class UpdateReviewDTO {
     }
 
     @Builder
-    public record Response(Long gameId, Long userId, Long reviewId, String reviewContent,
+    public record Response(Long gameId, String userName, Long reviewId, String reviewContent,
                            int reviewRank, LocalDateTime createdDate,
                            LocalDateTime lastModifiedDate) {
 
-        public static UpdateReviewDTO.Response of(Review review, UpdateReviewDTO.Request request) {
+        public static UpdateReviewDTO.Response of(User user, Review review, UpdateReviewDTO.Request request) {
             return Response.builder()
                     .gameId(review.getGameId())
-                    .userId(review.getUserId())
+                    .userName(user.getUserName())
                     .reviewId(review.getReviewId())
                     .reviewContent(request.reviewContent)
                     .reviewRank(request.reviewRank)

--- a/src/main/java/fourtalking/Nateam/review/service/ReviewService.java
+++ b/src/main/java/fourtalking/Nateam/review/service/ReviewService.java
@@ -1,5 +1,6 @@
 package fourtalking.Nateam.review.service;
 
+import fourtalking.Nateam.global.exception.review.InconsistencyUserIdException;
 import fourtalking.Nateam.global.exception.review.ReviewNotFoundException;
 import fourtalking.Nateam.review.dto.GetAllReviewDTO;
 import fourtalking.Nateam.review.dto.GetReviewDTO;
@@ -7,6 +8,8 @@ import fourtalking.Nateam.review.dto.ReviewRegisterDTO;
 import fourtalking.Nateam.review.dto.UpdateReviewDTO;
 import fourtalking.Nateam.review.entity.Review;
 import fourtalking.Nateam.review.repository.ReviewRepository;
+import fourtalking.Nateam.user.entity.User;
+import fourtalking.Nateam.user.service.UserService;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +18,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
-
+    private final UserService userService;
     private final ReviewRepository reviewRepository;
 
     public Review findById(Long reviewId) {
@@ -23,18 +26,20 @@ public class ReviewService {
         return reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
     }
 
-    public ReviewRegisterDTO.Response registerReview(Long gameId, ReviewRegisterDTO.Request reviewRequest) {
+    public ReviewRegisterDTO.Response registerReview(Long userId, Long gameId, ReviewRegisterDTO.Request reviewRequest) {
 
-        Review review = reviewRepository.save(reviewRequest.toEntity(gameId));
+        Review review = reviewRepository.save(reviewRequest.toEntity(userId, gameId));
+        User user = userService.findById(review.getUserId());
 
-        return ReviewRegisterDTO.Response.of(review);
+        return ReviewRegisterDTO.Response.of(user, review);
     }
 
-    public GetReviewDTO getReview(String userName, Long reviewId) {
+    public GetReviewDTO getReview(Long reviewId) {
 
         Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
+        User user = userService.findById(review.getUserId());
 
-        return GetReviewDTO.of(userName, review);
+        return GetReviewDTO.of(user, review);
     }
 
     public List<GetAllReviewDTO> getAllReview(Long gameId) {
@@ -43,16 +48,29 @@ public class ReviewService {
     }
 
     @Transactional
-    public UpdateReviewDTO.Response updateReview(Long reviewId, UpdateReviewDTO.Request request) {
+    public UpdateReviewDTO.Response updateReview(Long userId, Long reviewId,
+            UpdateReviewDTO.Request request) {
 
         Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
+        User user = userService.findById(review.getUserId());
+
+        if(!userId.equals(review.getUserId())){
+            throw new InconsistencyUserIdException();
+        }
+
         review.modify(request);
 
-        return UpdateReviewDTO.Response.of(review, request);
+        return UpdateReviewDTO.Response.of(user, review, request);
     }
 
     @Transactional
-    public void deleteReview(Long reviewId) {
+    public void deleteReview(Long userId, Long reviewId) {
+
+        Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
+
+        if(!userId.equals(review.getUserId())){
+            throw new InconsistencyUserIdException();
+        }
 
         reviewRepository.deleteById(reviewId);
     }


### PR DESCRIPTION
1. 모든 리뷰에 User 기능을 추가했습니다.

- 리뷰 등록 시 로그인한 유저의 ID를 받아와 리뷰에 ID가 저장되게 수정하였습니다.
- 리뷰 조회 / 전체조회 시에는 추가하지 않았습니다.
- 리뷰 수정 / 삭제 시 로그인한 유저와 리뷰의 UserID가 일치하면 수정/삭제되게 하였습니다.

2. 리뷰의 ResponseDTO가 순서가 뒤죽박죽이여서 API명세대로 순서를 수정하였습니다.