### PR TITLE
Refactor: 리뷰 DTO User객체 전달 -> UserName만 전달로 변경

### DIFF
--- a/src/main/java/fourtalking/Nateam/review/dto/GetReviewDTO.java
+++ b/src/main/java/fourtalking/Nateam/review/dto/GetReviewDTO.java
@@ -1,7 +1,6 @@
 package fourtalking.Nateam.review.dto;
 
 import fourtalking.Nateam.review.entity.Review;
-import fourtalking.Nateam.user.entity.User;
 import java.time.LocalDateTime;
 import lombok.Builder;
 
@@ -16,11 +15,11 @@ public record GetReviewDTO(
         LocalDateTime lastModifiedDate
 ) {
 
-    public static GetReviewDTO of(User user, Review review){
+    public static GetReviewDTO of(String userName, Review review){
 
         return GetReviewDTO.builder()
                 .gameId(review.getGameId())
-                .userName(user.getUserName())
+                .userName(userName)
                 .reviewId(review.getReviewId())
                 .reviewContent(review.getReviewContent())
                 .reviewRank(review.getReviewRank())

--- a/src/main/java/fourtalking/Nateam/review/dto/ReviewRegisterDTO.java
+++ b/src/main/java/fourtalking/Nateam/review/dto/ReviewRegisterDTO.java
@@ -1,7 +1,6 @@
 package fourtalking.Nateam.review.dto;
 
 import fourtalking.Nateam.review.entity.Review;
-import fourtalking.Nateam.user.entity.User;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -27,10 +26,10 @@ public class ReviewRegisterDTO{
     @Builder
     public record Response(Long gameId, String userName, Long reviewId, String reviewContent, int reviewRank, LocalDateTime createdDate) {
 
-        public static Response of(User user, Review review) {
+        public static Response of(String userName, Review review) {
             return Response.builder()
                     .gameId(review.getGameId())
-                    .userName(user.getUserName())
+                    .userName(userName)
                     .reviewId(review.getReviewId())
                     .reviewContent(review.getReviewContent())
                     .reviewRank(review.getReviewRank())

--- a/src/main/java/fourtalking/Nateam/review/dto/UpdateReviewDTO.java
+++ b/src/main/java/fourtalking/Nateam/review/dto/UpdateReviewDTO.java
@@ -1,7 +1,6 @@
 package fourtalking.Nateam.review.dto;
 
 import fourtalking.Nateam.review.entity.Review;
-import fourtalking.Nateam.user.entity.User;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -22,10 +21,10 @@ public class UpdateReviewDTO {
                            int reviewRank, LocalDateTime createdDate,
                            LocalDateTime lastModifiedDate) {
 
-        public static UpdateReviewDTO.Response of(User user, Review review, UpdateReviewDTO.Request request) {
+        public static UpdateReviewDTO.Response of(String userName, Review review, UpdateReviewDTO.Request request) {
             return Response.builder()
                     .gameId(review.getGameId())
-                    .userName(user.getUserName())
+                    .userName(userName)
                     .reviewId(review.getReviewId())
                     .reviewContent(request.reviewContent)
                     .reviewRank(request.reviewRank)

--- a/src/main/java/fourtalking/Nateam/review/service/ReviewService.java
+++ b/src/main/java/fourtalking/Nateam/review/service/ReviewService.java
@@ -29,17 +29,17 @@ public class ReviewService {
     public ReviewRegisterDTO.Response registerReview(Long userId, Long gameId, ReviewRegisterDTO.Request reviewRequest) {
 
         Review review = reviewRepository.save(reviewRequest.toEntity(userId, gameId));
-        User user = userService.findById(review.getUserId());
+        String userName = getUserName(review);
 
-        return ReviewRegisterDTO.Response.of(user, review);
+        return ReviewRegisterDTO.Response.of(userName, review);
     }
 
     public GetReviewDTO getReview(Long reviewId) {
 
         Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
-        User user = userService.findById(review.getUserId());
+        String userName = getUserName(review);
 
-        return GetReviewDTO.of(user, review);
+        return GetReviewDTO.of(userName, review);
     }
 
     public List<GetAllReviewDTO> getAllReview(Long gameId) {
@@ -52,7 +52,7 @@ public class ReviewService {
             UpdateReviewDTO.Request request) {
 
         Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
-        User user = userService.findById(review.getUserId());
+        String userName = getUserName(review);
 
         if(!userId.equals(review.getUserId())){
             throw new InconsistencyUserIdException();
@@ -60,7 +60,7 @@ public class ReviewService {
 
         review.modify(request);
 
-        return UpdateReviewDTO.Response.of(user, review, request);
+        return UpdateReviewDTO.Response.of(userName, review, request);
     }
 
     @Transactional
@@ -73,6 +73,13 @@ public class ReviewService {
         }
 
         reviewRepository.deleteById(reviewId);
+    }
+
+    private String getUserName(Review review){
+
+        User user = userService.findById(review.getUserId());
+
+        return user.getUserName();
     }
 }
 


### PR DESCRIPTION
리뷰의 응답 DTO들에 User 객체를 전달하는 방식에서
User를 찾아온 후 검색하여 UserName만 전달하는 방식으로 변경하였습니다.

그 과정에서 getUserName 메서드를 만들어 따로 빼 두었습니다.