### PR TITLE
Fix: 게임 단건 조회 - 게임 소개에 이름 소개가 담겨 반환

### DIFF
--- a/src/main/java/fourtalking/Nateam/game/dto/GameGetDTO.java
+++ b/src/main/java/fourtalking/Nateam/game/dto/GameGetDTO.java
@@ -20,7 +20,7 @@ public record GameGetDTO(
         return GameGetDTO.builder()
                 .gameId(game.getGameId())
                 .gameName(game.getGameName())
-                .gameIntroduction(game.getGameName())
+                .gameIntroduction(game.getGameIntroduction())
                 .gamePrice(game.getGamePrice())
                 .gameReviewRank(gameReviewRank)
                 .userName(userName)


### PR DESCRIPTION
## 세부 작업 내용
조회해온 게임을 DTO로 변경하는 GameGetDTO.of 메서드에서 게임 소개(gameIntroduction)에 게임소개가 아닌 게임 이름(gameName)이 담겨있는 코드 오류 발견

```java
// 변경 전
.gameIntroduction(game.getGameName())
// 변경 후
.gameIntroduction(game.getGameIntroduction())
```
게임 이름을 게임소개로 변경